### PR TITLE
Remove crack as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Changed
+- Removed Crack as a dependency of the metric script
+
 ## [0.1.0] - 2016-09-25
 ### Added
 - check-php-fpm.rb: added --pool option for mapping pools based on args in Nginx

--- a/bin/metrics-php-fpm.rb
+++ b/bin/metrics-php-fpm.rb
@@ -65,8 +65,8 @@ class PhpfpmMetrics < Sensu::Plugin::Metric::CLI::Graphite
               max_children_reached
               slow_requests)
     response.body.each_line do |line|
-      k, v = line.split(":").map(&:strip)
-      k.gsub! " ", "_"
+      k, v = line.split(':').map(&:strip)
+      k.tr! ' ', '_'
       output "#{config[:scheme]}.#{k}", v if stat.include? k
     end
     ok

--- a/sensu-plugins-php-fpm.gemspec
+++ b/sensu-plugins-php-fpm.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPhpFpm::Version::VER_STRING
 
-  s.add_runtime_dependency 'crack', '0.4.2'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [X] RuboCop passes
#### Purpose

This removes Crack as a dependency of the metric script, the plain text format is simple enough to parse
#### Known Compatablity Issues

I've compared the output of the current script and this one without Crack and they're identical, so there should be no issues here
