### PR TITLE
Better errors for missing/invalid URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Changed
 - Removed Crack as a dependency of the metric script
+- Better feedback for missing/invalid URL in the metric script
 
 ## [0.1.0] - 2016-09-25
 ### Added


### PR DESCRIPTION
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [X] RuboCop passes
#### Purpose

Gives better feedback for both giving no URL argument (currently a stack trace), or giving an invalid one (currently empty output)
